### PR TITLE
Fix error in a test example

### DIFF
--- a/src/test/java/fr/iutinfo/skeleton/api/RestClientTest.java
+++ b/src/test/java/fr/iutinfo/skeleton/api/RestClientTest.java
@@ -28,7 +28,7 @@ public class RestClientTest extends JerseyTest {
 
     @Test
     public void should_return_2_clients() {
-        String baseUrl = this.getBaseUri() + "/userdb/";
+        String baseUrl = this.getBaseUri() + "userdb/";
         RestClient client = new RestClient();
         client.addUser(new User(0, "Thomas"), baseUrl);
         client.addUser(new User(0, "Yann"), baseUrl);


### PR DESCRIPTION
A slash before the resource name is not necessary, getBaseUri() method return a string with a slash at end.
