### PR TITLE
Ajout de la méthode hashcode dans la class User

### DIFF
--- a/server/src/main/java/fr/iutinfo/skeleton/api/User.java
+++ b/server/src/main/java/fr/iutinfo/skeleton/api/User.java
@@ -104,6 +104,18 @@ public class User implements Principal {
     }
 
     @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((alias == null) ? 0 : alias.hashCode());
+        result = prime * result + ((email == null) ? 0 : email.hashCode());
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + ((passwdHash == null) ? 0 : passwdHash.hashCode());
+        result = prime * result + ((salt == null) ? 0 : salt.hashCode());
+        return result;
+    }
+    
+    @Override
     public String toString() {
         return id + ": " + alias + ", " + name + " <" + email + ">";
     }


### PR DESCRIPTION
A class that overrides only one of equals and hashCode is likely to violate the contract of the hashCode method. The contract requires that hashCode gives the same integer result for any two equal objects. Not enforcing this property may cause unexpected results when storing and retrieving objects of such a class in a hashing data structure.